### PR TITLE
Backfill missing lab metadata (8 files)

### DIFF
--- a/Instructions/Labs/LAB[PL-7001]_M00L00_Validate_lab_environment.md
+++ b/Instructions/Labs/LAB[PL-7001]_M00L00_Validate_lab_environment.md
@@ -3,7 +3,7 @@ lab:
   title: 'Lab 0: Validate lab environment'
   module: 'Module 0: Course Introduction'
   description: In this exercise, you will verify that you can access Power Apps.
-  duration: 48 minutes
+  duration: 10 minutes
   level: 100
   islab: true
   primarytopics:

--- a/Instructions/Labs/LAB[PL-7001]_M00L00_Validate_lab_environment.md
+++ b/Instructions/Labs/LAB[PL-7001]_M00L00_Validate_lab_environment.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 0: Validate lab environment'
-    module: 'Module 0: Course Introduction'
+  title: 'Lab 0: Validate lab environment'
+  module: 'Module 0: Course Introduction'
+  description: In this exercise, you will verify that you can access Power Apps.
+  duration: 48 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Power Apps
 ---
 
 # Practice Lab 0 - Validate lab environment

--- a/Instructions/Labs/LAB[PL-7001]_M01L01_Canvas_app_from_data.md
+++ b/Instructions/Labs/LAB[PL-7001]_M01L01_Canvas_app_from_data.md
@@ -3,7 +3,7 @@ lab:
   title: 'Lab 1: Create a canvas app from data'
   module: 'Module 1: Get started with Power Apps canvas apps'
   description: In this lab you will design and build a canvas app from an existing data source.
-  duration: 132 minutes
+  duration: 20 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/LAB[PL-7001]_M01L01_Canvas_app_from_data.md
+++ b/Instructions/Labs/LAB[PL-7001]_M01L01_Canvas_app_from_data.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 1: Create a canvas app from data'
-    module: 'Module 1: Get started with Power Apps canvas apps'
+  title: 'Lab 1: Create a canvas app from data'
+  module: 'Module 1: Get started with Power Apps canvas apps'
+  description: In this lab you will design and build a canvas app from an existing data source.
+  duration: 132 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 1 – Create a canvas app from data

--- a/Instructions/Labs/LAB[PL-7001]_M02L01_Data_model.md
+++ b/Instructions/Labs/LAB[PL-7001]_M02L01_Data_model.md
@@ -3,7 +3,7 @@ lab:
   title: 'Lab 2: Data model'
   module: 'Module 2: Get started with Microsoft Dataverse'
   description: In this lab you will create Dataverse tables and columns.
-  duration: 156 minutes
+  duration: 40 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/LAB[PL-7001]_M02L01_Data_model.md
+++ b/Instructions/Labs/LAB[PL-7001]_M02L01_Data_model.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 2: Data model'
-    module: 'Module 2: Get started with Microsoft Dataverse'
+  title: 'Lab 2: Data model'
+  module: 'Module 2: Get started with Microsoft Dataverse'
+  description: In this lab you will create Dataverse tables and columns.
+  duration: 156 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 2 – Data model

--- a/Instructions/Labs/LAB[PL-7001]_M03L01_Canvas_app.md
+++ b/Instructions/Labs/LAB[PL-7001]_M03L01_Canvas_app.md
@@ -3,7 +3,7 @@ lab:
   title: 'Lab 3: Create a canvas app'
   module: 'Module 3: Customize a canvas app in Power Apps'
   description: In this lab you will design and build a canvas app from blank, add a data source and a gallery.
-  duration: 150 minutes
+  duration: 45 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/LAB[PL-7001]_M03L01_Canvas_app.md
+++ b/Instructions/Labs/LAB[PL-7001]_M03L01_Canvas_app.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 3: Create a canvas app'
-    module: 'Module 3: Customize a canvas app in Power Apps'
+  title: 'Lab 3: Create a canvas app'
+  module: 'Module 3: Customize a canvas app in Power Apps'
+  description: In this lab you will design and build a canvas app from blank, add a data source and a gallery.
+  duration: 150 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 3 – Create a canvas app

--- a/Instructions/Labs/LAB[PL-7001]_M04L01_Build_UI.md
+++ b/Instructions/Labs/LAB[PL-7001]_M04L01_Build_UI.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 4: Build the UI'
-    module: 'Module 4: How to build the UI in a canvas app in Power Apps'
+  title: 'Lab 4: Build the UI'
+  module: 'Module 4: How to build the UI in a canvas app in Power Apps'
+  description: In this lab you will change the colors of the controls in the app.
+  duration: 92 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 4 – Build the UI

--- a/Instructions/Labs/LAB[PL-7001]_M04L01_Build_UI.md
+++ b/Instructions/Labs/LAB[PL-7001]_M04L01_Build_UI.md
@@ -3,7 +3,7 @@ lab:
   title: 'Lab 4: Build the UI'
   module: 'Module 4: How to build the UI in a canvas app in Power Apps'
   description: In this lab you will change the colors of the controls in the app.
-  duration: 92 minutes
+  duration: 10 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
+++ b/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 5: External data'
-    module: 'Module 5: Work with external data in a Power Apps canvas app'
+  title: 'Lab 5: External data'
+  module: 'Module 5: Work with external data in a Power Apps canvas app'
+  description: In this lab you will add an external data source.
+  duration: 168 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 5 – External data

--- a/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
+++ b/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
@@ -3,7 +3,7 @@ lab:
   title: 'Lab 5: External data'
   module: 'Module 5: Work with external data in a Power Apps canvas app'
   description: In this lab you will add an external data source.
-  duration: 168 minutes
+  duration: 30 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/LAB[PL-7001]_M06L01_Forms.md
+++ b/Instructions/Labs/LAB[PL-7001]_M06L01_Forms.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 6: Forms'
-    module: 'Module 6: Write data in a Power Apps canvas app'
+  title: 'Lab 6: Forms'
+  module: 'Module 6: Write data in a Power Apps canvas app'
+  description: In this lab you will use forms to create and edit records in a data source.
+  duration: 164 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 6 – Forms

--- a/Instructions/Labs/LAB[PL-7001]_M06L01_Forms.md
+++ b/Instructions/Labs/LAB[PL-7001]_M06L01_Forms.md
@@ -3,7 +3,7 @@ lab:
   title: 'Lab 6: Forms'
   module: 'Module 6: Write data in a Power Apps canvas app'
   description: In this lab you will use forms to create and edit records in a data source.
-  duration: 164 minutes
+  duration: 45 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/LAB[PL-7001]_M07L01_Manage.md
+++ b/Instructions/Labs/LAB[PL-7001]_M07L01_Manage.md
@@ -3,7 +3,7 @@ lab:
   title: 'Lab 7: Manage canvas apps'
   module: 'Module 7: Publish, share, and maintain a canvas app'
   description: In this lab you will manage your canvas app.
-  duration: 84 minutes
+  duration: 10 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/LAB[PL-7001]_M07L01_Manage.md
+++ b/Instructions/Labs/LAB[PL-7001]_M07L01_Manage.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 7: Manage canvas apps'
-    module: 'Module 7: Publish, share, and maintain a canvas app'
+  title: 'Lab 7: Manage canvas apps'
+  module: 'Module 7: Publish, share, and maintain a canvas app'
+  description: In this lab you will manage your canvas app.
+  duration: 84 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 7 – Manage canvas apps


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 8

- `Instructions/Labs/LAB[PL-7001]_M00L00_Validate_lab_environment.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB[PL-7001]_M01L01_Canvas_app_from_data.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7001]_M02L01_Data_model.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7001]_M03L01_Canvas_app.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7001]_M04L01_Build_UI.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7001]_M06L01_Forms.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7001]_M07L01_Manage.md` (description,duration,level,islab)
