### PR TITLE
PL-7001- Lab 3: Align canvas app creation steps with current Power Apps UI

### DIFF
--- a/Instructions/Labs/LAB[PL-7001]_M03L01_Canvas_app.md
+++ b/Instructions/Labs/LAB[PL-7001]_M03L01_Canvas_app.md
@@ -46,7 +46,7 @@ In this lab you will design and build a canvas app from blank, add a data source
 
 1. Wait for the blank app to be built.
 
-1. Select **Save** in the top-right of the Power Apps Studio, enter `Booking Request app`, and select **Save**.
+1. Select **Save** in the top-right of the Power Apps Studio, enter `Booking Request app` for **Name**, and then select **Save**.
 
 ### Task 1.2 - Add data source
 

--- a/Instructions/Labs/LAB[PL-7001]_M03L01_Canvas_app.md
+++ b/Instructions/Labs/LAB[PL-7001]_M03L01_Canvas_app.md
@@ -70,7 +70,7 @@ In this lab you will design and build a canvas app from blank, add a data source
 
 1. In the app authoring menu, select **Insert (+)**.
 
-1. Select **Rectangle**.
+1. Expand the **Shapes** category and select **Rectangle**.
 
 1. Drag the rectangle to the top left of the screen.
 

--- a/Instructions/Labs/LAB[PL-7001]_M03L01_Canvas_app.md
+++ b/Instructions/Labs/LAB[PL-7001]_M03L01_Canvas_app.md
@@ -40,7 +40,7 @@ In this lab you will design and build a canvas app from blank, add a data source
 
 1. Select the **+ Create** tab from the left navigation menu.
 
-1. Select the **Start with a blank canvas** tile under **Create your apps**.
+1. Select the **Create from blank** tile under **Start from design**.
 
 1. Select **Tablet size**.
 


### PR DESCRIPTION
## Summary

This pull request updates **Lab 3** to align the canvas app creation instructions with the **current Power Apps UI** and terminology. The changes improve clarity and accuracy in the app creation flow, ensuring learners follow steps that match the latest Power Apps Studio experience.

---

## Changes

- Updated the canvas app creation step to reflect the current **Create from blank** option under **Start from design**.
- Removed outdated references to **Start with a blank canvas** under **Create your apps**.
- Clarified the **Save** step by explicitly specifying the **Name** field when entering the app name.
- Improved consistency of UI labels and wording to match the current Power Apps interface.
- Improved the shape selection step by clarifying how to expand the Shapes category and select Rectangle, ensuring consistency with the current Power Apps UI
---

## Files changed

- `Instructions/Labs/LAB[PL-7001]_M03L01_Canvas_app.md`
