### PR TITLE
PL-7001 - Lab 5 - Clarify UI instructions and add note for missing Country profile value

### DIFF
--- a/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
+++ b/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
@@ -293,6 +293,7 @@ In this lab you will add an external data source.
     ```powerappsfl
     Office365Users.MyProfile().Country
     ```
+> **Note:** If the user´s country is not displayed, go to `https://admin.microsoft.com`, select **Users** > **Active users**, open the user profile, select **Manage contact information**, and then set the **Country or region** field.
 
 1. Set the properties of the label in the formula bar as follows:
 

--- a/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
+++ b/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
@@ -206,7 +206,7 @@ In this lab you will add an external data source.
 
 1. In the app authoring menu, select **Insert (+)**.
 
-1. Expand **Icons**.
+1. Expand **Classic Icons**.
 
 1. Select **Blocked**. The icon will be added to each row in the gallery.
 

--- a/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
+++ b/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
@@ -206,7 +206,7 @@ In this lab you will add an external data source.
 
 1. In the app authoring menu, select **Insert (+)**.
 
-1. Expand **Icons**.
+1. Expand **Classic icons**.
 
 1. Select **Blocked**. The icon will be added to each row in the gallery.
 
@@ -239,7 +239,7 @@ In this lab you will add an external data source.
 
 1. In the app authoring menu, select **Insert (+)**.
 
-1. Expand **Icons**.
+1. Expand **Classic icons**.
 
 1. Select **Add**. The icon will be added to each row in the gallery.
 

--- a/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
+++ b/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
@@ -43,7 +43,7 @@ In this lab you will add an external data source.
 
 1. In SharePoint, select **+ Create site**.
 
-1. Select **Team site**, select **Standard team** template, and select **Use template**.
+1. Select **Team site**, select **Standard team** template, and then select **Use template**.
 
 1. Enter `Pet boarding` for **Site name** and select **Next**.
 

--- a/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
+++ b/Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md
@@ -206,7 +206,7 @@ In this lab you will add an external data source.
 
 1. In the app authoring menu, select **Insert (+)**.
 
-1. Expand **Classic Icons**.
+1. Expand **Icons**.
 
 1. Select **Blocked**. The icon will be added to each row in the gallery.
 


### PR DESCRIPTION
## Summary  
This pull request improves **PL-7001 –  Lab 5 –  External data** lab instructions by aligning steps with the current Power Apps Studio UI and by adding a troubleshooting note to address a common lab blocker related to the **Country or region** user profile field.

These updates improve clarity, accuracy, and learner success when following the lab.

---

## Changes  
- Updated the team site creation step to improve clarity and align with current UI wording:
- Updated icon selection steps to reflect the current **Classic icons** grouping in Power Apps Studio.
- Added a **Note** explaining how to populate the **Country or region** field when `Office365Users.MyProfile().Country` returns a blank value in Power Apps Studio.

## Files changed

`Instructions/Labs/LAB[PL-7001]_M05L01_External_data.md`

